### PR TITLE
feat: implement OAuth authentication with Google and GitHub

### DIFF
--- a/apps/web/vettly-web/package-lock.json
+++ b/apps/web/vettly-web/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.72.0",
         "react-router-dom": "^7.13.2",
+        "react-toastify": "^11.0.5",
         "tailwindcss": "^4.2.2",
         "zod": "^4.3.6",
         "zustand": "^5.0.12"
@@ -1806,6 +1807,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3289,6 +3299,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/resolve-from": {

--- a/apps/web/vettly-web/package.json
+++ b/apps/web/vettly-web/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.72.0",
     "react-router-dom": "^7.13.2",
+    "react-toastify": "^11.0.5",
     "tailwindcss": "^4.2.2",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"

--- a/apps/web/vettly-web/src/api/auth/endpoints.ts
+++ b/apps/web/vettly-web/src/api/auth/endpoints.ts
@@ -4,3 +4,9 @@ export const AUTH_ENDPOINTS = {
   LOGOUT: "/api/auth/logout",
   REFRESH: "/api/auth/refresh",
 } as const;
+
+export const AUTH_ERRORS = {
+  ACCOUNT_NOT_FOUND: "account_not_found",
+  OAUTH_FAILED: "oauth_failed",
+  NO_EMAIL: "no_email",
+} as const;

--- a/apps/web/vettly-web/src/main.tsx
+++ b/apps/web/vettly-web/src/main.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import "./index.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router-dom";
+import { Bounce, Slide, ToastContainer } from "react-toastify";
 import { router } from "./router/index.tsx";
 import { useAuthStore } from "./stores/authStore.ts";
 import { AUTH_ENDPOINTS } from "./api/auth/endpoints.ts";
@@ -16,7 +17,7 @@ if (isAuthenticated && !accessToken && user) {
     const r = await axios.post(
       `${import.meta.env.VITE_AUTH_API_URL}${AUTH_ENDPOINTS.REFRESH}`,
       { userId: user.id },
-      { withCredentials: true }
+      { withCredentials: true },
     );
     setAccessToken(r.data.accessToken);
   } catch {
@@ -37,6 +38,13 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <ToastContainer
+        position="top-right"
+        autoClose={4000}
+        theme="light"
+        newestOnTop
+        transition={Slide}
+      />
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/web/vettly-web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/vettly-web/src/pages/auth/LoginPage.tsx
@@ -1,8 +1,12 @@
-import { Link, useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { toast } from "react-toastify";
 import { ROUTES } from "../../router/routes";
 import { z } from "zod";
 import { useAuthStore } from "../../stores/authStore";
 import { useLogin } from "../../api/auth/auth.api";
+import { AUTH_ERRORS } from "../../api/auth/endpoints";
+import { UserRole } from "../../types/auth.types";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -15,8 +19,15 @@ type LoginForm = z.infer<typeof loginSchema>;
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { user } = useAuthStore();
   const login = useLogin();
+
+  useEffect(() => {
+    if (searchParams.get("error") === AUTH_ERRORS.ACCOUNT_NOT_FOUND) {
+      toast.error("No account found. Please register first.");
+    }
+  }, []);
 
   const {
     register,
@@ -27,14 +38,16 @@ export default function LoginPage() {
   });
 
   if (user) {
-    navigate(user.role === "recruiter" ? ROUTES.RECRUITER : ROUTES.CANDIDATE);
+    navigate(user.role === UserRole.Recruiter ? ROUTES.RECRUITER : ROUTES.CANDIDATE);
   }
 
   const onSubmit = (data: LoginForm) => {
     login.mutate(data, {
       onSuccess: () => {
         const { user } = useAuthStore.getState();
-        navigate(user?.role === "recruiter" ? ROUTES.RECRUITER : ROUTES.CANDIDATE);
+        navigate(
+          user?.role === UserRole.Recruiter ? ROUTES.RECRUITER : ROUTES.CANDIDATE
+        );
       },
       onError: (error: any) => {
         console.error(error.response?.data?.message ?? "Login failed");
@@ -43,61 +56,211 @@ export default function LoginPage() {
   };
 
   return (
-    <div style={{ maxWidth: 400, margin: "100px auto", padding: 24 }}>
-      <h1>Sign in to Vettly</h1>
+    <div className="min-h-screen bg-surface flex">
+      {/* ── Left panel: editorial dark branding ── */}
+      <div className="hidden lg:flex lg:w-1/2 editorial-gradient flex-col justify-between p-12 relative overflow-hidden">
+        {/* Ambient glow blobs */}
+        <div className="absolute -bottom-32 -left-32 w-96 h-96 bg-secondary/20 rounded-full blur-3xl pointer-events-none" />
+        <div className="absolute top-10 right-0 w-72 h-72 bg-secondary-fixed/10 rounded-full blur-3xl pointer-events-none" />
 
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <div style={{ marginBottom: 16 }}>
-          <label htmlFor="email">Email</label>
-          <input
-            {...register("email")}
-            id="email"
-            type="email"
-            style={{ display: "block", width: "100%", padding: 8 }}
-          />
-          {errors.email && (
-            <span style={{ color: "red" }}>{errors.email.message}</span>
-          )}
-        </div>
-
-        <div style={{ marginBottom: 16 }}>
-          <label htmlFor="password">Password</label>
-          <input
-            {...register("password")}
-            id="password"
-            type="password"
-            style={{ display: "block", width: "100%", padding: 8 }}
-          />
-          {errors.password && (
-            <span style={{ color: "red" }}>{errors.password.message}</span>
-          )}
-        </div>
-
-        <button
-          type="submit"
-          disabled={login.isPending}
-          style={{
-            width: "100%",
-            padding: 10,
-            background: "#534AB7",
-            color: "white",
-            border: "none",
-            cursor: "pointer",
-          }}
+        <Link
+          to={ROUTES.ROOT}
+          className="text-2xl font-black tracking-tighter font-headline text-white relative z-10"
         >
-          {login.isPending ? "Signing in..." : "Sign in"}
-        </button>
+          Vettly
+        </Link>
 
-        {login.isError && (
-          <p style={{ color: "red" }}>
-            {(login.error as any)?.response?.data?.message ?? "Login failed"}
+        <div className="relative z-10 space-y-8">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-secondary/20 text-secondary-fixed-dim text-xs font-bold tracking-widest uppercase font-label">
+            <span className="material-symbols-outlined text-[14px]">auto_awesome</span>
+            {" "}AI-Powered Recruitment
+          </div>
+
+          <div className="space-y-4">
+            <h2 className="text-4xl font-extrabold font-headline text-white leading-tight">
+              Hire smarter.
+              <br />
+              Get hired faster.
+            </h2>
+            <p className="text-primary-fixed-dim text-lg leading-relaxed font-body max-w-sm">
+              NLP screening, bias detection, and semantic matching. All in one
+              platform.
+            </p>
+          </div>
+
+          <div className="space-y-4 pt-2">
+            {[
+              { icon: "psychology", label: "NLP Resume Scoring", sub: "Beyond keyword matching" },
+              { icon: "diversity_3", label: "Bias Detection Built-In", sub: "Demographic fairness metrics" },
+              { icon: "draw", label: "E-Sign & Close", sub: "Offer to signed in one flow" },
+            ].map(({ icon, label, sub }) => (
+              <div key={label} className="flex items-center gap-4">
+                <div className="w-10 h-10 rounded-xl bg-secondary/20 flex items-center justify-center text-secondary-fixed-dim shrink-0">
+                  <span className="material-symbols-outlined text-[20px]">{icon}</span>
+                </div>
+                <div>
+                  <div className="font-headline font-bold text-sm text-white">{label}</div>
+                  <div className="font-label text-xs tracking-wider uppercase text-primary-fixed-dim">
+                    {sub}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <p className="text-xs font-label text-primary-fixed-dim relative z-10">
+          © {new Date().getFullYear()} Vettly. All rights reserved.
+        </p>
+      </div>
+
+      {/* ── Right panel: form ── */}
+      <div className="flex-1 flex flex-col justify-center items-center px-6 py-12 bg-surface">
+        {/* Mobile logo */}
+        <Link
+          to={ROUTES.ROOT}
+          className="lg:hidden text-2xl font-black tracking-tighter font-headline text-primary mb-10"
+        >
+          Vettly
+        </Link>
+
+        <div className="w-full max-w-md space-y-8">
+          <div>
+            <h1 className="text-3xl font-extrabold font-headline text-primary">
+              Welcome back
+            </h1>
+            <p className="mt-2 text-on-surface-variant font-body text-sm">
+              Sign in to your Vettly account to continue.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+            {/* Email */}
+            <div className="space-y-1.5">
+              <label
+                htmlFor="email"
+                className="block text-xs font-bold font-label tracking-widest uppercase text-on-surface-variant"
+              >
+                Email Address
+              </label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-[18px] text-on-surface-variant pointer-events-none">
+                  mail
+                </span>
+                <input
+                  {...register("email")}
+                  id="email"
+                  type="email"
+                  autoComplete="email"
+                  placeholder="you@example.com"
+                  className="w-full pl-10 pr-4 py-3.5 rounded-xl bg-surface-container-high text-on-surface font-body text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:bg-surface-container-highest border-b-2 border-transparent focus:border-secondary transition-all"
+                />
+              </div>
+              {errors.email && (
+                <p className="text-error text-xs font-label flex items-center gap-1">
+                  <span className="material-symbols-outlined text-[14px]">error</span>
+                  {" "}{errors.email.message}
+                </p>
+              )}
+            </div>
+
+            {/* Password */}
+            <div className="space-y-1.5">
+              <label
+                htmlFor="password"
+                className="block text-xs font-bold font-label tracking-widest uppercase text-on-surface-variant"
+              >
+                Password
+              </label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-[18px] text-on-surface-variant pointer-events-none">
+                  lock
+                </span>
+                <input
+                  {...register("password")}
+                  id="password"
+                  type="password"
+                  autoComplete="current-password"
+                  placeholder="••••••••"
+                  className="w-full pl-10 pr-4 py-3.5 rounded-xl bg-surface-container-high text-on-surface font-body text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:bg-surface-container-highest border-b-2 border-transparent focus:border-secondary transition-all"
+                />
+              </div>
+              {errors.password && (
+                <p className="text-error text-xs font-label flex items-center gap-1">
+                  <span className="material-symbols-outlined text-[14px]">error</span>
+                  {" "}{errors.password.message}
+                </p>
+              )}
+            </div>
+
+            {login.isError && (
+              <div className="flex items-center gap-2 px-4 py-3 rounded-xl bg-error-container text-on-error-container text-sm font-body">
+                <span className="material-symbols-outlined text-[18px]">warning</span>
+                {" "}{(login.error as any)?.response?.data?.message ?? "Invalid email or password."}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={login.isPending}
+              className="w-full bg-primary text-on-primary py-4 rounded-xl font-headline font-bold text-base hover:opacity-80 active:scale-95 transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {login.isPending ? (
+                <>
+                  <span className="material-symbols-outlined text-[18px] animate-spin">progress_activity</span>
+                  {" "}Signing in…
+                </>
+              ) : (
+                "Sign In"
+              )}
+            </button>
+          </form>
+
+          {/* OR divider */}
+          <div className="relative flex items-center gap-4">
+            <div className="flex-1 h-px bg-surface-container-high" />
+            <span className="text-xs font-label tracking-widest uppercase text-on-surface-variant">or</span>
+            <div className="flex-1 h-px bg-surface-container-high" />
+          </div>
+
+          {/* Google */}
+          <button
+            type="button"
+            onClick={() => { globalThis.location.href = "http://localhost:5050/api/auth/google?mode=login"; }}
+            className="w-full flex items-center justify-center gap-3 bg-surface-container-low hover:bg-surface-container py-3.5 rounded-xl font-headline font-bold text-sm text-on-surface transition-all"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/>
+              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+            </svg>
+            Continue with Google
+          </button>
+
+          {/* GitHub */}
+          <button
+            type="button"
+            onClick={() => { globalThis.location.href = "http://localhost:5050/api/auth/github?mode=login"; }}
+            className="w-full flex items-center justify-center gap-3 bg-surface-container-low hover:bg-surface-container py-3.5 rounded-xl font-headline font-bold text-sm text-on-surface transition-all"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
+              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+            </svg>
+            Continue with GitHub
+          </button>
+
+          <p className="text-center text-sm font-body text-on-surface-variant">
+            Don't have an account?{" "}
+            <Link
+              to={ROUTES.AUTH.REGISTER}
+              className="font-bold text-secondary hover:underline"
+            >
+              Get started for free
+            </Link>
           </p>
-        )}
-      </form>
-
-      <p style={{ marginTop: 16 }}>
-        Don't have an account? <Link to={ROUTES.AUTH.REGISTER}>Register</Link>
-      </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/vettly-web/src/pages/auth/OAuthCallbackPage.tsx
+++ b/apps/web/vettly-web/src/pages/auth/OAuthCallbackPage.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useAuthStore } from "../../stores/authStore";
+import { ROUTES } from "../../router/routes";
+import { UserRole } from "../../types/auth.types";
+
+const extractUser = (token: string) => {
+  const payload = JSON.parse(atob(token.split(".")[1]));
+  return {
+    id:        payload.sub as string,
+    email:     payload.email as string,
+    role:      payload.role as UserRole,
+    firstName: payload.firstName as string,
+    lastName:  (payload.lastName ?? "") as string,
+  };
+};
+
+export default function OAuthCallbackPage() {
+  const [params]    = useSearchParams();
+  const navigate    = useNavigate();
+  const { setAuth } = useAuthStore();
+
+  useEffect(() => {
+    const token = params.get("token");
+    const error = params.get("error");
+
+    if (error || !token) {
+      navigate(`${ROUTES.AUTH.LOGIN}?error=oauth_failed`, { replace: true });
+      return;
+    }
+
+    const user = extractUser(token);
+    setAuth(user, token);
+    navigate(user.role === UserRole.Recruiter ? ROUTES.RECRUITER : ROUTES.CANDIDATE, { replace: true });
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-surface flex items-center justify-center">
+      <div className="flex flex-col items-center gap-4">
+        <span className="material-symbols-outlined text-[48px] text-secondary animate-spin">
+          progress_activity
+        </span>
+        <p className="font-headline font-bold text-primary text-lg">Signing you in...</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/vettly-web/src/pages/auth/RegisterPage.tsx
+++ b/apps/web/vettly-web/src/pages/auth/RegisterPage.tsx
@@ -3,6 +3,7 @@ import z from "zod";
 import { ROUTES } from "../../router/routes";
 import { useRegister } from "../../api/auth/auth.api";
 import { useAuthStore } from "../../stores/authStore";
+import { UserRole } from "../../types/auth.types";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -15,126 +16,375 @@ const registerSchema = z.object({
 });
 
 type RegisterForm = z.infer<typeof registerSchema>;
+
 export default function RegisterPage() {
   const navigate = useNavigate();
   const register_ = useRegister();
   const { user } = useAuthStore();
 
   if (user) {
-    navigate(user.role === "recruiter" ? ROUTES.RECRUITER : ROUTES.CANDIDATE);
+    navigate(user.role === UserRole.Recruiter ? ROUTES.RECRUITER : ROUTES.CANDIDATE);
   }
 
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors },
   } = useForm<RegisterForm>({
     resolver: zodResolver(registerSchema),
-    defaultValues: { role: "candidate" },
+    defaultValues: { role: UserRole.Candidate },
   });
+
+  const selectedRole = watch("role");
 
   const onSubmit = (data: RegisterForm) => {
     register_.mutate(data, {
       onSuccess: () => {
         const user = useAuthStore.getState().user;
-        navigate(user?.role === "recruiter" ? ROUTES.RECRUITER : ROUTES.CANDIDATE);
+        navigate(
+          user?.role === UserRole.Recruiter ? ROUTES.RECRUITER : ROUTES.CANDIDATE
+        );
       },
     });
   };
 
   return (
-    <div style={{ maxWidth: 400, margin: "80px auto", padding: 24 }}>
-      <h1>Create your Vettly account</h1>
+    <div className="min-h-screen bg-surface flex">
+      {/* ── Left panel: editorial dark branding ── */}
+      <div className="hidden lg:flex lg:w-1/2 editorial-gradient flex-col justify-between p-12 relative overflow-hidden">
+        {/* Ambient glow blobs */}
+        <div className="absolute -bottom-32 -left-32 w-96 h-96 bg-secondary/20 rounded-full blur-3xl pointer-events-none" />
+        <div className="absolute top-10 right-0 w-72 h-72 bg-secondary-fixed/10 rounded-full blur-3xl pointer-events-none" />
 
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <div style={{ marginBottom: 12 }}>
-          <label htmlFor="firstName">First name</label>
-          <input
-            {...register("firstName")}
-            id="firstName"
-            style={{ display: "block", width: "100%", padding: 8 }}
-          />
-          {errors.firstName && (
-            <span style={{ color: "red" }}>{errors.firstName.message}</span>
-          )}
-        </div>
-
-        <div style={{ marginBottom: 12 }}>
-          <label htmlFor="lastName">Last name</label>
-          <input
-            {...register("lastName")}
-            id="lastName"
-            style={{ display: "block", width: "100%", padding: 8 }}
-          />
-          {errors.lastName && (
-            <span style={{ color: "red" }}>{errors.lastName.message}</span>
-          )}
-        </div>
-
-        <div style={{ marginBottom: 12 }}>
-          <label htmlFor="email">Email</label>
-          <input
-            {...register("email")}
-            id="email"
-            type="email"
-            style={{ display: "block", width: "100%", padding: 8 }}
-          />
-          {errors.email && (
-            <span style={{ color: "red" }}>{errors.email.message}</span>
-          )}
-        </div>
-
-        <div style={{ marginBottom: 12 }}>
-          <label htmlFor="password">Password</label>
-          <input
-            {...register("password")}
-            id="password"
-            type="password"
-            style={{ display: "block", width: "100%", padding: 8 }}
-          />
-          {errors.password && (
-            <span style={{ color: "red" }}>{errors.password.message}</span>
-          )}
-        </div>
-
-        <div style={{ marginBottom: 16 }}>
-          <label htmlFor="role">I am a</label>
-          <select
-            {...register("role")}
-            id="role"
-            style={{ display: "block", width: "100%", padding: 8 }}
-          >
-            <option value="candidate">Candidate — looking for a job</option>
-            <option value="recruiter">Recruiter — hiring talent</option>
-          </select>
-        </div>
-
-        <button
-          type="submit"
-          disabled={register_.isPending}
-          style={{
-            width: "100%",
-            padding: 10,
-            background: "#534AB7",
-            color: "white",
-            border: "none",
-            cursor: "pointer",
-          }}
+        <Link
+          to={ROUTES.ROOT}
+          className="text-2xl font-black tracking-tighter font-headline text-white relative z-10"
         >
-          {register_.isPending ? "Creating account..." : "Create account"}
-        </button>
+          Vettly
+        </Link>
 
-        {register_.isError && (
-          <p style={{ color: "red" }}>
-            {(register_.error as any)?.response?.data?.message ??
-              "Registration failed"}
+        <div className="relative z-10 space-y-8">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-secondary/20 text-secondary-fixed-dim text-xs font-bold tracking-widest uppercase font-label">
+            <span className="material-symbols-outlined text-[14px]">auto_awesome</span>
+            {" "}Smart Recruitment
+          </div>
+
+          <div className="space-y-4">
+            <h2 className="text-4xl font-extrabold font-headline text-white leading-tight">
+              Your next great
+              <br />
+              hire starts here.
+            </h2>
+            <p className="text-primary-fixed-dim text-lg leading-relaxed font-body max-w-sm">
+              Join thousands of recruiters and candidates using Vettly to
+              connect faster and fairer.
+            </p>
+          </div>
+
+          {/* Mini pipeline preview */}
+          <div className="bg-white/5 backdrop-blur-sm rounded-2xl p-5 space-y-3 max-w-xs">
+            <p className="text-xs font-bold font-label uppercase tracking-widest text-primary-fixed-dim mb-2">
+              Live Match · React Engineer
+            </p>
+            {[
+              { name: "Alex Chen", score: "94%", stage: "Matched" },
+              { name: "Priya Nair", score: "89%", stage: "Interview" },
+            ].map((c) => (
+              <div
+                key={c.name}
+                className="flex items-center justify-between px-3 py-2.5 rounded-xl bg-white/8"
+              >
+                <div className="flex items-center gap-2">
+                  <div className="w-7 h-7 rounded-full bg-secondary flex items-center justify-center text-on-secondary text-xs font-bold font-label">
+                    {c.name[0]}
+                  </div>
+                  <span className="font-body text-xs font-medium text-white">
+                    {c.name}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-bold text-secondary-fixed-dim font-label">
+                    AI {c.score}
+                  </span>
+                  <span className="text-[10px] font-bold font-label uppercase tracking-wider px-2 py-0.5 rounded-full text-on-secondary bg-secondary">
+                    {c.stage}
+                  </span>
+                </div>
+              </div>
+            ))}
+            <div className="pt-1 flex items-center gap-1.5 text-xs font-label text-secondary-fixed-dim">
+              <span className="material-symbols-outlined text-[14px]">verified_user</span>
+              {" "}Bias check: Passed
+            </div>
+          </div>
+        </div>
+
+        <p className="text-xs font-label text-primary-fixed-dim relative z-10">
+          © {new Date().getFullYear()} Vettly. All rights reserved.
+        </p>
+      </div>
+
+      {/* ── Right panel: form ── */}
+      <div className="flex-1 flex flex-col justify-center items-center px-6 py-12 bg-surface overflow-y-auto">
+        {/* Mobile logo */}
+        <Link
+          to={ROUTES.ROOT}
+          className="lg:hidden text-2xl font-black tracking-tighter font-headline text-primary mb-10"
+        >
+          Vettly
+        </Link>
+
+        <div className="w-full max-w-md space-y-7">
+          <div>
+            <h1 className="text-3xl font-extrabold font-headline text-primary">
+              Create your account
+            </h1>
+            <p className="mt-2 text-on-surface-variant font-body text-sm">
+              Join Vettly and start hiring or get hired smarter.
+            </p>
+          </div>
+
+          {/* Role selector */}
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              {
+                value: UserRole.Candidate,
+                icon: "person_search",
+                label: "Candidate",
+                sub: "Looking for a job",
+              },
+              {
+                value: UserRole.Recruiter,
+                icon: "work",
+                label: "Recruiter",
+                sub: "Hiring talent",
+              },
+            ].map(({ value, icon, label, sub }) => {
+              const active = selectedRole === value;
+              return (
+                <label
+                  key={value}
+                  htmlFor={`role-${value}`}
+                  className={`relative flex flex-col items-center gap-2 p-4 rounded-xl cursor-pointer transition-all ${
+                    active
+                      ? "bg-secondary-container"
+                      : "bg-surface-container-low hover:bg-surface-container"
+                  }`}
+                >
+                  <input
+                    {...register("role")}
+                    type="radio"
+                    id={`role-${value}`}
+                    value={value}
+                    className="sr-only"
+                  />
+                  <span
+                    className={`material-symbols-outlined text-[28px] ${
+                      active ? "text-on-secondary-container" : "text-on-surface-variant"
+                    }`}
+                  >
+                    {icon}
+                  </span>
+                  <span
+                    className={`font-headline font-bold text-sm ${
+                      active ? "text-on-secondary-container" : "text-on-surface"
+                    }`}
+                  >
+                    {label}
+                  </span>
+                  <span
+                    className={`font-label text-xs text-center ${
+                      active ? "text-on-secondary-container" : "text-on-surface-variant"
+                    }`}
+                  >
+                    {sub}
+                  </span>
+                  {active && (
+                    <span className="absolute top-2 right-2 material-symbols-outlined text-[16px] text-on-secondary-container">
+                      check_circle
+                    </span>
+                  )}
+                </label>
+              );
+            })}
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            {/* Name row */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <label
+                  htmlFor="firstName"
+                  className="block text-xs font-bold font-label tracking-widest uppercase text-on-surface-variant"
+                >
+                  First Name
+                </label>
+                <input
+                  {...register("firstName")}
+                  id="firstName"
+                  autoComplete="given-name"
+                  placeholder="Alex"
+                  className="w-full px-4 py-3.5 rounded-xl bg-surface-container-high text-on-surface font-body text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:bg-surface-container-highest border-b-2 border-transparent focus:border-secondary transition-all"
+                />
+                {errors.firstName && (
+                  <p className="text-error text-xs font-label flex items-center gap-1">
+                    <span className="material-symbols-outlined text-[14px]">error</span>
+                    {" "}{errors.firstName.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1.5">
+                <label
+                  htmlFor="lastName"
+                  className="block text-xs font-bold font-label tracking-widest uppercase text-on-surface-variant"
+                >
+                  Last Name
+                </label>
+                <input
+                  {...register("lastName")}
+                  id="lastName"
+                  autoComplete="family-name"
+                  placeholder="Chen"
+                  className="w-full px-4 py-3.5 rounded-xl bg-surface-container-high text-on-surface font-body text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:bg-surface-container-highest border-b-2 border-transparent focus:border-secondary transition-all"
+                />
+                {errors.lastName && (
+                  <p className="text-error text-xs font-label flex items-center gap-1">
+                    <span className="material-symbols-outlined text-[14px]">error</span>
+                    {" "}{errors.lastName.message}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* Email */}
+            <div className="space-y-1.5">
+              <label
+                htmlFor="email"
+                className="block text-xs font-bold font-label tracking-widest uppercase text-on-surface-variant"
+              >
+                Email Address
+              </label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-[18px] text-on-surface-variant pointer-events-none">
+                  mail
+                </span>
+                <input
+                  {...register("email")}
+                  id="email"
+                  type="email"
+                  autoComplete="email"
+                  placeholder="you@example.com"
+                  className="w-full pl-10 pr-4 py-3.5 rounded-xl bg-surface-container-high text-on-surface font-body text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:bg-surface-container-highest border-b-2 border-transparent focus:border-secondary transition-all"
+                />
+              </div>
+              {errors.email && (
+                <p className="text-error text-xs font-label flex items-center gap-1">
+                  <span className="material-symbols-outlined text-[14px]">error</span>
+                  {" "}{errors.email.message}
+                </p>
+              )}
+            </div>
+
+            {/* Password */}
+            <div className="space-y-1.5">
+              <label
+                htmlFor="password"
+                className="block text-xs font-bold font-label tracking-widest uppercase text-on-surface-variant"
+              >
+                Password
+              </label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-[18px] text-on-surface-variant pointer-events-none">
+                  lock
+                </span>
+                <input
+                  {...register("password")}
+                  id="password"
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder="Min. 8 characters"
+                  className="w-full pl-10 pr-4 py-3.5 rounded-xl bg-surface-container-high text-on-surface font-body text-sm placeholder:text-on-surface-variant/50 focus:outline-none focus:bg-surface-container-highest border-b-2 border-transparent focus:border-secondary transition-all"
+                />
+              </div>
+              {errors.password && (
+                <p className="text-error text-xs font-label flex items-center gap-1">
+                  <span className="material-symbols-outlined text-[14px]">error</span>
+                  {" "}{errors.password.message}
+                </p>
+              )}
+            </div>
+
+            {register_.isError && (
+              <div className="flex items-center gap-2 px-4 py-3 rounded-xl bg-error-container text-on-error-container text-sm font-body">
+                <span className="material-symbols-outlined text-[18px]">warning</span>
+                {" "}{(register_.error as any)?.response?.data?.message ??
+                  "Registration failed. Please try again."}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={register_.isPending}
+              className="w-full bg-primary text-on-primary py-4 rounded-xl font-headline font-bold text-base hover:opacity-80 active:scale-95 transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {register_.isPending ? (
+                <>
+                  <span className="material-symbols-outlined text-[18px] animate-spin">progress_activity</span>
+                  {" "}Creating account…
+                </>
+              ) : (
+                "Create Account"
+              )}
+            </button>
+          </form>
+
+          {/* OR divider */}
+          <div className="relative flex items-center gap-4">
+            <div className="flex-1 h-px bg-surface-container-high" />
+            <span className="text-xs font-label tracking-widest uppercase text-on-surface-variant">or</span>
+            <div className="flex-1 h-px bg-surface-container-high" />
+          </div>
+
+          {/* Google */}
+          <button
+            type="button"
+            onClick={() => { globalThis.location.href = `http://localhost:5050/api/auth/google?role=${selectedRole}`; }}
+            className="w-full flex items-center justify-center gap-3 bg-surface-container-low hover:bg-surface-container py-3.5 rounded-xl font-headline font-bold text-sm text-on-surface transition-all"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/>
+              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+            </svg>
+            Continue with Google
+          </button>
+
+          {/* GitHub */}
+          <button
+            type="button"
+            onClick={() => { globalThis.location.href = `http://localhost:5050/api/auth/github?role=${selectedRole}`; }}
+            className="w-full flex items-center justify-center gap-3 bg-surface-container-low hover:bg-surface-container py-3.5 rounded-xl font-headline font-bold text-sm text-on-surface transition-all"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
+              <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+            </svg>
+            Continue with GitHub
+          </button>
+
+          <p className="text-center text-sm font-body text-on-surface-variant">
+            Already have an account?{" "}
+            <Link
+              to={ROUTES.AUTH.LOGIN}
+              className="font-bold text-secondary hover:underline"
+            >
+              Sign in
+            </Link>
           </p>
-        )}
-      </form>
-
-      <p style={{ marginTop: 16 }}>
-        Already have an account? <Link to={ROUTES.AUTH.LOGIN}>Sign in</Link>
-      </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/vettly-web/src/router/index.tsx
+++ b/apps/web/vettly-web/src/router/index.tsx
@@ -1,9 +1,10 @@
 import { createBrowserRouter, Navigate, useNavigate } from "react-router-dom";
 import { useAuthStore } from "../stores/authStore";
-import type { UserRole } from "../types/auth.types";
+import { UserRole } from "../types/auth.types";
 import LandingPage from "../pages/LandingPage";
 import LoginPage from "../pages/auth/LoginPage";
 import RegisterPage from "../pages/auth/RegisterPage";
+import OAuthCallbackPage from "../pages/auth/OAuthCallbackPage";
 import { useLogout } from "../api/auth/auth.api";
 import { ROUTES } from "./routes";
 
@@ -53,9 +54,13 @@ export const router = createBrowserRouter([
     element: <RegisterPage />,
   },
   {
+    path: ROUTES.AUTH.CALLBACK,
+    element: <OAuthCallbackPage />,
+  },
+  {
     path: ROUTES.CANDIDATE,
     element: (
-      <RoleRoute allowedRole="candidate">
+      <RoleRoute allowedRole={UserRole.Candidate}>
         <div>Candidate Dashboard — coming soon<br /><LogoutButton /></div>
       </RoleRoute>
     ),
@@ -63,7 +68,7 @@ export const router = createBrowserRouter([
   {
     path: ROUTES.RECRUITER,
     element: (
-      <RoleRoute allowedRole="recruiter">
+      <RoleRoute allowedRole={UserRole.Recruiter}>
         <div>Recruiter Dashboard — coming soon<br /><LogoutButton /></div>
       </RoleRoute>
     ),

--- a/apps/web/vettly-web/src/router/routes.ts
+++ b/apps/web/vettly-web/src/router/routes.ts
@@ -3,6 +3,7 @@ export const ROUTES = {
   AUTH: {
     LOGIN: "/auth/login",
     REGISTER: "/auth/register",
+    CALLBACK: "/auth/callback",
   },
   CANDIDATE: "/candidate",
   RECRUITER: "/recruiter",

--- a/apps/web/vettly-web/src/types/auth.types.ts
+++ b/apps/web/vettly-web/src/types/auth.types.ts
@@ -1,7 +1,7 @@
 export const UserRole = {
   Candidate: "candidate",
   Recruiter: "recruiter",
-};
+}as const;
 
 export type UserRole = (typeof UserRole)[keyof typeof UserRole];
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,11 @@ services:
       - Jwt__RefreshTokenExpirationDays=1
       - Redis__ConnectionString=redis:6379
       - Cors__AllowedOrigins__0=${CORS_ALLOWED_ORIGIN}
+      - OAuth__Google__ClientId=${GOOGLE_CLIENT_ID}
+      - OAuth__Google__ClientSecret=${GOOGLE_CLIENT_SECRET}
+      - OAuth__GitHub__ClientId=${GITHUB_CLIENT_ID}
+      - OAuth__GitHub__ClientSecret=${GITHUB_CLIENT_SECRET}
+      - Frontend__BaseUrl=${FRONTEND_BASE_URL}
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/auth-service/Controllers/OAuthController.cs
+++ b/services/auth-service/Controllers/OAuthController.cs
@@ -1,0 +1,111 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using Vettly.AuthService.Data;
+using Vettly.AuthService.Models;
+using Vettly.AuthService.Services;
+
+namespace Vettly.AuthService.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class OAuthController : ControllerBase
+{
+    private readonly AuthDbContext  _db;
+    private readonly ITokenService  _tokenService;
+    private readonly IConfiguration _config;
+
+    public OAuthController(AuthDbContext db, ITokenService tokenService, IConfiguration config)
+    {
+        _db           = db;
+        _tokenService = tokenService;
+        _config       = config;
+    }
+
+    private const string DefaultRole = "candidate";
+    private static readonly string[] AllowedRoles = ["candidate", "recruiter"];
+
+    [HttpGet("google")]
+    public IActionResult Google([FromQuery] string role = DefaultRole, [FromQuery] string mode = "register")
+    {
+        if (!AllowedRoles.Contains(role)) role = DefaultRole;
+
+        return Challenge(new AuthenticationProperties
+        {
+            RedirectUri = $"/api/auth/oauth/callback?role={role}&mode={mode}"
+        }, "Google");
+    }
+
+    [HttpGet("github")]
+    public IActionResult GitHub([FromQuery] string role = DefaultRole, [FromQuery] string mode = "register")
+    {
+        if (!AllowedRoles.Contains(role)) role = DefaultRole;
+
+        return Challenge(new AuthenticationProperties
+        {
+            RedirectUri = $"/api/auth/oauth/callback?role={role}&mode={mode}"
+        }, "GitHub");
+    }
+
+    [HttpGet("oauth/callback")]
+    public async Task<IActionResult> Callback([FromQuery] string role = DefaultRole, [FromQuery] string mode = "register")
+    {
+        if (!AllowedRoles.Contains(role)) role = DefaultRole;
+
+        var frontendUrl = _config["Frontend:BaseUrl"]!;
+        var result = await HttpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        if (!result.Succeeded)
+            return Redirect($"{frontendUrl}/auth/login?error=oauth_failed");
+
+        var claims    = result.Principal!.Claims.ToList();
+        var email     = claims.FirstOrDefault(claim => claim.Type == ClaimTypes.Email)?.Value;
+        var firstName = claims.FirstOrDefault(claim => claim.Type == ClaimTypes.GivenName)?.Value
+                        ?? claims.FirstOrDefault(claim => claim.Type == ClaimTypes.Name)?.Value
+                        ?? "User";
+        var lastName  = claims.FirstOrDefault(claim => claim.Type == ClaimTypes.Surname)?.Value ?? "";
+
+        if (email is null)
+            return Redirect($"{frontendUrl}/auth/login?error=no_email");
+
+        var normalizedEmail = email.ToLowerInvariant();
+        var isNewUser = false;
+        var user = await _db.Users.FirstOrDefaultAsync(user => user.Email == normalizedEmail);
+
+        if (user is null)
+        {
+            if (mode == "login")
+                return Redirect($"{frontendUrl}/auth/login?error=account_not_found");
+
+            isNewUser = true;
+            user = new User
+            {
+                Email        = normalizedEmail,
+                PasswordHash = string.Empty,
+                Role         = role,
+                FirstName    = firstName,
+                LastName     = lastName,
+            };
+            _db.Users.Add(user);
+            await _db.SaveChangesAsync();
+        }
+
+        var accessToken  = _tokenService.GenerateAccessToken(user);
+        var refreshToken = _tokenService.GenerateRefreshToken();
+        await _tokenService.StoreRefreshTokenAsync(user.Id, refreshToken);
+
+        Response.Cookies.Append("refreshToken", refreshToken, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure   = Request.IsHttps,
+            SameSite = SameSiteMode.None,
+            Path     = "/api/auth",
+            Expires  = DateTime.UtcNow.AddDays(
+                int.Parse(_config["Jwt:RefreshTokenExpirationDays"]!))
+        });
+
+        return Redirect($"{frontendUrl}/auth/callback?token={accessToken}&isNewUser={isNewUser}");
+    }
+}

--- a/services/auth-service/Program.cs
+++ b/services/auth-service/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -19,9 +20,20 @@ var redisConfig = ConfigurationOptions.Parse(builder.Configuration["Redis:Connec
 redisConfig.AbortOnConnectFail = false;
 builder.Services.AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(redisConfig));
 
-//JWT Authentication
+//JWT Authentication And OAuth Authentication
 var jwtSettings = builder.Configuration.GetSection("Jwt");
-builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultScheme             = CookieAuthenticationDefaults.AuthenticationScheme;
+    options.DefaultSignInScheme       = CookieAuthenticationDefaults.AuthenticationScheme;
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options =>
+{
+    options.Cookie.SameSite     = SameSiteMode.Lax;
+    options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+})
+.AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, options =>
 {
     options.MapInboundClaims = false;
     options.TokenValidationParameters = new TokenValidationParameters
@@ -35,6 +47,17 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJw
         IssuerSigningKey = new SymmetricSecurityKey(
             Encoding.UTF8.GetBytes(jwtSettings["SecretKey"]!)),
     };
+})
+.AddGoogle(options =>
+{
+    options.ClientId     = builder.Configuration["OAuth:Google:ClientId"]!;
+    options.ClientSecret = builder.Configuration["OAuth:Google:ClientSecret"]!;
+})
+.AddGitHub(options =>
+{
+    options.ClientId = builder.Configuration["OAuth:GitHub:ClientId"]!;
+    options.ClientSecret = builder.Configuration["OAuth:GitHub:ClientSecret"]!;
+    options.Scope.Add("user:email");
 });
 
 //Services

--- a/services/auth-service/Vettly.AuthService.csproj
+++ b/services/auth-service/Vettly.AuthService.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">

--- a/services/auth-service/appsettings.json
+++ b/services/auth-service/appsettings.json
@@ -21,5 +21,18 @@
   },
   "Cors": {
     "AllowedOrigins": []
+  },
+  "OAuth": {
+    "Google": {
+      "ClientId": "",
+      "ClientSecret": ""
+    },
+    "GitHub": {
+      "ClientId": "",
+      "ClientSecret": ""
+    }
+  },
+  "Frontend": {
+    "BaseUrl": ""
   }
 }


### PR DESCRIPTION
## Description

Adds Google and GitHub OAuth authentication alongside the existing email/password flow. Users can register or sign in using their Google or GitHub account. The OAuth flow issues the same JWT + HttpOnly refresh token cookie as the standard login, keeping the auth infrastructure consistent. Role selection (Candidate/Recruiter) is preserved through the OAuth chain on the register page. The login page blocks account creation via OAuth and unknown accounts are redirected back with a toast error.

## Type of Change

- [x] ✨ New feature (non-breaking change adding functionality)
- [x] 🔒 Security enhancement

## Related Issue

Closes #7 

## Affected Services/Apps

- [x] Web App (`apps/web`)
- [x] Backend Services (`services/`)
- [x] Docker/Infrastructure

## Changes Made

<!-- Provide a detailed list of changes -->

### Core Changes

- Added multi-scheme authentication to `Program.cs` (Cookie + JWT + Google + GitHub) — `DefaultAuthenticateScheme` stays JWT so existing `[Authorize]` endpoints are unaffected
- Implemented `OAuthController` with `/api/auth/google`, `/api/auth/github` challenge endpoints and a shared `/api/auth/oauth/callback` that finds-or-creates the user, issues JWT + refresh token cookie, and redirects to the frontend

### Additional Changes

- Added `mode` query param (`login` | `register`) through the OAuth chain — login mode blocks account creation and redirects with `error=account_not_found`
- Added `role` query param through the OAuth chain so register page role selection (Candidate/Recruiter) is respected for new OAuth users
- Created `OAuthCallbackPage.tsx` — decodes JWT from redirect URL, calls `setAuth`, navigates to dashboard
- Added Google and GitHub sign-in buttons (with SVG icons, design system styling) to both `LoginPage` and `RegisterPage`
- Added `AUTH_ERRORS` constants to `endpoints.ts` to replace magic error strings
- Added `as const` to `UserRole` object and replaced all `"recruiter"`/`"candidate"` string literals across pages and router
- Mounted `react-toastify` `ToastContainer` in `main.tsx`; login page shows toast on `account_not_found` error
- Added `Frontend:BaseUrl` to `appsettings.json` for the backend redirect target

## Technical Details

OAuth uses a browser redirect chain, not an API call, so the access token cannot be returned in a JSON body. Instead the backend appends it as a URL query param (`?token=...`) on the redirect to `/auth/callback`. The frontend callback page reads it immediately and discards it from the URL. The HttpOnly refresh token cookie is set identically to the standard login flow — the same `/api/auth/refresh` endpoint handles renewal for both auth methods.

The temporary ASP.NET cookie (`SameSite=Lax`) is only used internally by the OAuth library during the challenge → Google/GitHub → callback round-trip. It is not the same as the application refresh token cookie.

## Testing

- [x] Manual testing completed
- [x] Tested in Docker environment

### Manual Test Steps

1. Navigate to Register page, select **Recruiter**, click **Continue with Google** → complete Google login → should land on `/recruiter`
2. Delete that user from DB, repeat with **Candidate** selected → should land on `/candidate`
3. Navigate to Login page, click **Continue with Google** with an email that has no account → should redirect back to login with toast: *"No account found. Please register first."*
4. Register via email/password as recruiter, then sign in via **Continue with GitHub** with the same email → should log into the existing recruiter account (no duplicate created)
5. Repeat steps 1–4 with the GitHub buttons

## Database Changes

- [x] No database changes

OAuth users are stored in the existing `Users` table with `PasswordHash = ""`. No schema migration required.

## Security Considerations

- [x] Credentials/secrets properly handled
- [x] Input validation implemented
- [x] Authentication/authorization verified

`OAuth:Google:ClientId`, `OAuth:Google:ClientSecret`, `OAuth:GitHub:ClientId`, `OAuth:GitHub:ClientSecret` are stored in .NET User Secrets — not in `appsettings.json` or source control. Role and mode query params are validated server-side against an allowlist before use.

## Performance Impact

- [x] No performance impact

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] Requires environment variable updates

### Environment Variables

<!-- List any new or modified environment variables -->

```
GOOGLE_CLIENT_ID=your-google-client-id
GOOGLE_CLIENT_SECRET=your-google-client-secret
GITHUB_CLIENT_ID=your-github-client-id
GITHUB_CLIENT_SECRET=your-github-client-secret
FRONTEND_BASE_URL=http://localhost:5173
```

## Dependencies

- [x] Dependencies documented below

### Added Dependencies

- `Microsoft.AspNetCore.Authentication.Google` v10.0.5 — Google OAuth handler for ASP.NET Core
- `AspNet.Security.OAuth.GitHub` v9.0.0 — GitHub OAuth handler (aspnet-contrib)
- `react-toastify` — toast notifications (already added by user)

## Rollback Plan

Remove `.AddGoogle(...)` and `.AddGitHub(...)` from `Program.cs` and revert `DefaultScheme`/`DefaultSignInScheme` to `JwtBearerDefaults.AuthenticationScheme`. Remove the OAuth buttons from the frontend pages. No database migration to reverse.

---

<!--
For Reviewers:
- Verify code quality and adherence to standards
- Check test coverage and edge cases
- Validate security implications
- Review performance impact
- Ensure documentation is complete
-->
