### PR TITLE
Adding Unauthorized and 404 pages

### DIFF
--- a/apps/web/vettly-web/src/pages/NotFoundPage.tsx
+++ b/apps/web/vettly-web/src/pages/NotFoundPage.tsx
@@ -1,0 +1,114 @@
+import { Link, useNavigate } from "react-router-dom";
+import { ROUTES } from "../router/routes";
+import { ThemeToggle } from "../components/ThemeToggle";
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-surface text-on-surface flex flex-col">
+      {/* Nav */}
+      <nav className="fixed top-0 w-full z-50 bg-surface/80 backdrop-blur-xl shadow-sm border-b border-outline-variant/30">
+        <div className="flex justify-between items-center px-6 py-4 max-w-7xl mx-auto">
+          <Link
+            to={ROUTES.ROOT}
+            className="text-xl font-bold tracking-tighter text-on-surface font-headline"
+          >
+            Vettly
+          </Link>
+          <ThemeToggle />
+        </div>
+      </nav>
+
+      {/* Content */}
+      <main className="flex-1 flex items-center justify-center px-6 pt-24 pb-12">
+        <div className="max-w-lg w-full text-center space-y-8">
+          {/* Icon + 404 */}
+          <div className="flex flex-col items-center gap-4 select-none">
+            <div className="w-20 h-20 rounded-full bg-secondary-container flex items-center justify-center">
+              <span className="material-symbols-outlined text-[40px] text-on-secondary-container">
+                search_off
+              </span>
+            </div>
+            <span className="text-[8rem] font-extrabold font-headline leading-none text-primary-container">
+              404
+            </span>
+          </div>
+
+          {/* Heading */}
+          <div className="space-y-2">
+            <div className="text-xs font-bold font-label tracking-widest text-on-surface-variant uppercase">
+              Page Not Found
+            </div>
+            <h1 className="text-4xl font-extrabold font-headline text-primary leading-tight">
+              Nothing here yet.
+            </h1>
+            <p className="text-lg text-on-surface-variant font-body leading-relaxed">
+              The page you're looking for doesn't exist or may have been moved.
+              Let's get you back on track.
+            </p>
+          </div>
+
+          {/* Quick links */}
+          <div className="bg-surface-container-low rounded-2xl p-5 space-y-2 text-left">
+            <p className="text-xs font-bold font-label uppercase tracking-widest text-on-surface-variant mb-3">
+              Try these instead
+            </p>
+            {[
+              { icon: "home", label: "Home", to: ROUTES.ROOT },
+              { icon: "login", label: "Sign In", to: ROUTES.AUTH.LOGIN },
+              {
+                icon: "person_add",
+                label: "Create Account",
+                to: ROUTES.AUTH.REGISTER,
+              },
+            ].map(({ icon, label, to }) => (
+              <Link
+                key={to}
+                to={to}
+                className="flex items-center gap-3 px-4 py-3 rounded-xl hover:bg-surface-container transition-all text-on-surface-variant hover:text-on-surface group"
+              >
+                <span className="material-symbols-outlined text-[18px] text-secondary group-hover:text-primary transition-colors">
+                  {icon}
+                </span>
+                <span className="font-body text-sm font-medium">{label}</span>
+                <span className="material-symbols-outlined text-[16px] ml-auto opacity-0 group-hover:opacity-100 transition-opacity">
+                  arrow_forward
+                </span>
+              </Link>
+            ))}
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <button
+              onClick={() => navigate(-1)}
+              className="flex items-center justify-center gap-2 border-2 border-outline-variant text-primary px-6 py-3 rounded-xl font-headline font-bold hover:bg-surface-container transition-all"
+            >
+              <span className="material-symbols-outlined text-[18px]">
+                arrow_back
+              </span>
+              Go Back
+            </button>
+            <Link
+              to={ROUTES.ROOT}
+              className="flex items-center justify-center gap-2 bg-primary text-on-primary px-6 py-3 rounded-xl font-headline font-bold hover:opacity-90 transition-all"
+            >
+              <span className="material-symbols-outlined text-[18px]">
+                home
+              </span>
+              Go Home
+            </Link>
+          </div>
+        </div>
+      </main>
+
+      {/* Footer strip */}
+      <div className="border-t border-outline-variant/40 py-6 px-6 text-center">
+        <p className="text-on-surface-variant text-sm font-body">
+          © {new Date().getFullYear()} Vettly. Hire smarter. Get hired faster.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/vettly-web/src/pages/UnauthorizedPage.tsx
+++ b/apps/web/vettly-web/src/pages/UnauthorizedPage.tsx
@@ -1,0 +1,113 @@
+import { Link, useNavigate } from "react-router-dom";
+import { ROUTES } from "../router/routes";
+import { ThemeToggle } from "../components/ThemeToggle";
+import { useAuthStore } from "../stores/authStore";
+import { UserRole } from "../types/auth.types";
+
+export default function UnauthorizedPage() {
+  const navigate = useNavigate();
+  const { isAuthenticated, user } = useAuthStore();
+
+  const dashboardRoute =
+    user?.role === UserRole.Recruiter ? ROUTES.RECRUITER : ROUTES.CANDIDATE;
+
+  return (
+    <div className="min-h-screen bg-surface text-on-surface flex flex-col">
+      {/* Nav */}
+      <nav className="fixed top-0 w-full z-50 bg-surface/80 backdrop-blur-xl shadow-sm border-b border-outline-variant/30">
+        <div className="flex justify-between items-center px-6 py-4 max-w-7xl mx-auto">
+          <Link
+            to={ROUTES.ROOT}
+            className="text-xl font-bold tracking-tighter text-on-surface font-headline"
+          >
+            Vettly
+          </Link>
+          <ThemeToggle />
+        </div>
+      </nav>
+
+      {/* Content */}
+      <main className="flex-1 flex items-center justify-center px-6 pt-24 pb-12">
+        <div className="max-w-lg w-full text-center space-y-8">
+          {/* Icon badge */}
+          <div className="flex justify-center">
+            <div className="w-24 h-24 rounded-full bg-error-container flex items-center justify-center">
+              <span className="material-symbols-outlined text-[48px] text-on-error-container">
+                lock
+              </span>
+            </div>
+          </div>
+
+          {/* Code + heading */}
+          <div className="space-y-2">
+            <div className="text-xs font-bold font-label tracking-widest text-on-surface-variant uppercase">
+              Error 401
+            </div>
+            <h1 className="text-5xl font-extrabold font-headline text-primary leading-tight">
+              Access Denied
+            </h1>
+            <p className="text-lg text-on-surface-variant font-body leading-relaxed">
+              You don't have permission to view this page. This area is
+              restricted to a different role.
+            </p>
+          </div>
+
+          {/* Role pill */}
+          {user?.role && (
+            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-surface-container-low border border-outline-variant text-sm font-label text-on-surface-variant">
+              <span className="material-symbols-outlined text-[16px]">
+                badge
+              </span>
+              Signed in as{" "}
+              <span className="font-bold text-on-surface capitalize">
+                {user.role}
+              </span>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+            <button
+              onClick={() => navigate(-1)}
+              className="flex items-center justify-center gap-2 border-2 border-outline-variant text-primary px-6 py-3 rounded-xl font-headline font-bold hover:bg-surface-container transition-all"
+            >
+              <span className="material-symbols-outlined text-[18px]">
+                arrow_back
+              </span>
+              Go Back
+            </button>
+
+            {isAuthenticated ? (
+              <Link
+                to={dashboardRoute}
+                className="flex items-center justify-center gap-2 bg-primary text-on-primary px-6 py-3 rounded-xl font-headline font-bold hover:opacity-90 transition-all"
+              >
+                <span className="material-symbols-outlined text-[18px]">
+                  dashboard
+                </span>
+                My Dashboard
+              </Link>
+            ) : (
+              <Link
+                to={ROUTES.AUTH.LOGIN}
+                className="flex items-center justify-center gap-2 bg-primary text-on-primary px-6 py-3 rounded-xl font-headline font-bold hover:opacity-90 transition-all"
+              >
+                <span className="material-symbols-outlined text-[18px]">
+                  login
+                </span>
+                Sign In
+              </Link>
+            )}
+          </div>
+        </div>
+      </main>
+
+      {/* Footer strip */}
+      <div className="border-t border-outline-variant/40 py-6 px-6 text-center">
+        <p className="text-on-surface-variant text-sm font-body">
+          © {new Date().getFullYear()} Vettly. Hire smarter. Get hired faster.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/vettly-web/src/router/index.tsx
+++ b/apps/web/vettly-web/src/router/index.tsx
@@ -5,6 +5,8 @@ import LandingPage from "../pages/LandingPage";
 import LoginPage from "../pages/auth/LoginPage";
 import RegisterPage from "../pages/auth/RegisterPage";
 import OAuthCallbackPage from "../pages/auth/OAuthCallbackPage";
+import UnauthorizedPage from "../pages/UnauthorizedPage";
+import NotFoundPage from "../pages/NotFoundPage";
 import { useLogout } from "../api/auth/auth.api";
 import { ROUTES } from "./routes";
 
@@ -75,6 +77,10 @@ export const router = createBrowserRouter([
   },
   {
     path: ROUTES.UNAUTHORIZED,
-    element: <div>Unauthorized</div>,
+    element: <UnauthorizedPage />,
+  },
+  {
+    path: "*",
+    element: <NotFoundPage />,
   },
 ]);


### PR DESCRIPTION
## Description

Adds dedicated 401 Unauthorized and 404 Not Found error pages to the Vettly web app, replacing the previous inline placeholder `<div>` elements. Both pages follow the existing design system (Material Symbols icons, Tailwind token classes, `font-headline`/`font-body`/`font-label`) and include the `ThemeToggle` component for full dark/light mode support.

## Type of Change

- [x] ✨ New feature (non-breaking change adding functionality)
- [x] 🎨 UI/UX improvement

## Related Issue

Closes #12 

## Affected Services/Apps

- [x] Web App (`apps/web`)

## Changes Made

### Core Changes

- Added `UnauthorizedPage.tsx` — 401 page shown when a user's role doesn't match the required role for a route; displays the user's current role, a "Go Back" button, and a "My Dashboard" / "Sign In" CTA depending on auth state
- Added `NotFoundPage.tsx` — catch-all 404 page with a quick-links card and "Go Back" / "Go Home" actions

### Additional Changes

- Updated `router/index.tsx` to import and use both new pages; replaced placeholder `<div>` on `/unauthorized` and added a `*` catch-all route for 404

## Technical Details

`UnauthorizedPage` reads `user.role` from `useAuthStore` and uses the `UserRole` enum to determine the correct dashboard link. The 404 route is registered as a `*` wildcard — the last entry in the router — so it catches any unmatched path. Both pages are standalone (no shared layout wrapper) to keep error recovery self-contained.

## Testing

- [x] Manual testing completed

### Manual Test Steps

1. Navigate to `http://localhost:5173/some-random-path` → 404 page renders.
2. Navigate to `http://localhost:5173/unauthorized` → 401 page renders with no role pill (unauthenticated).
3. Log in as a candidate, then navigate to `/recruiter` → `RoleRoute` guard redirects to `/unauthorized`; role pill shows "candidate".
4. Click "My Dashboard" → redirects to `/candidate`.
5. Click "Go Back" on either page → browser navigates back.
6. Toggle dark/light mode on both pages → theme applies correctly.

## Database Changes

- [x] No database changes

## Security Considerations

- [x] No security impact

## Performance Impact

- [x] No performance impact

## Breaking Changes

- [x] No breaking changes

## Deployment Notes

- [x] No special deployment steps

## Checklist

### Code Quality

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No commented-out code or debug logs

### Version Control

- [x] Commits are clear and descriptive
- [x] PR title is clear and descriptive

## Screenshots/Videos

<img width="1918" height="860" alt="404 page" src="https://github.com/user-attachments/assets/04ca8ba4-80bf-4c26-b907-421db0f00740" />

<img width="1918" height="867" alt="unauthorized" src="https://github.com/user-attachments/assets/93c81f8e-0cc6-4192-a55d-2ab3296c737c" />

## Dependencies

- [x] No new dependencies
