### PR TITLE
feat: update CandidateProfile to include AvatarKey and remove S3Url from Resume

### DIFF
--- a/services/candidate-service/Data/CandidateDbContext.cs
+++ b/services/candidate-service/Data/CandidateDbContext.cs
@@ -35,6 +35,7 @@ namespace Vettly.CandidateService.Data
                 entity.Property(entity => entity.Headline).HasMaxLength(255);
                 entity.Property(entity => entity.Phone).HasMaxLength(15);
                 entity.Property(entity => entity.Location).HasMaxLength(100);
+                entity.Property(entity => entity.AvatarKey).HasMaxLength(500);
             });
             modelBuilder.Entity<Experience>(entity =>
             {
@@ -80,7 +81,6 @@ namespace Vettly.CandidateService.Data
                     .OnDelete(DeleteBehavior.Cascade);
                 entity.Property(entity => entity.FileName).IsRequired().HasMaxLength(255);
                 entity.Property(entity => entity.S3Key).IsRequired().HasMaxLength(500);
-                entity.Property(entity => entity.S3Url).IsRequired().HasMaxLength(500);
             });
 
             modelBuilder.Entity<Application>(entity =>

--- a/services/candidate-service/Migrations/20260607042258_RemoveResumeS3Url.Designer.cs
+++ b/services/candidate-service/Migrations/20260607042258_RemoveResumeS3Url.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Vettly.CandidateService.Data;
@@ -11,9 +12,11 @@ using Vettly.CandidateService.Data;
 namespace Vettly.CandidateService.Migrations
 {
     [DbContext(typeof(CandidateDbContext))]
-    partial class CandidateDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260607042258_RemoveResumeS3Url")]
+    partial class RemoveResumeS3Url
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -77,10 +80,6 @@ namespace Vettly.CandidateService.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
-
-                    b.Property<string>("AvatarKey")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)");
 
                     b.Property<string>("AvatarUrl")
                         .HasColumnType("text");

--- a/services/candidate-service/Migrations/20260607042258_RemoveResumeS3Url.cs
+++ b/services/candidate-service/Migrations/20260607042258_RemoveResumeS3Url.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Vettly.CandidateService.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveResumeS3Url : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "S3Url",
+                schema: "candidate",
+                table: "Resumes");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "S3Url",
+                schema: "candidate",
+                table: "Resumes",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/services/candidate-service/Migrations/20260607042957_AddCandidateAvatarKey.Designer.cs
+++ b/services/candidate-service/Migrations/20260607042957_AddCandidateAvatarKey.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Vettly.CandidateService.Data;
@@ -11,9 +12,11 @@ using Vettly.CandidateService.Data;
 namespace Vettly.CandidateService.Migrations
 {
     [DbContext(typeof(CandidateDbContext))]
-    partial class CandidateDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260607042957_AddCandidateAvatarKey")]
+    partial class AddCandidateAvatarKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/candidate-service/Migrations/20260607042957_AddCandidateAvatarKey.cs
+++ b/services/candidate-service/Migrations/20260607042957_AddCandidateAvatarKey.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Vettly.CandidateService.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCandidateAvatarKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AvatarKey",
+                schema: "candidate",
+                table: "Profiles",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AvatarKey",
+                schema: "candidate",
+                table: "Profiles");
+        }
+    }
+}

--- a/services/candidate-service/Models/CandidateProfile.cs
+++ b/services/candidate-service/Models/CandidateProfile.cs
@@ -28,6 +28,8 @@
 
         public string? AvatarUrl { get; set; }
 
+        public string? AvatarKey { get; set; }
+
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/services/candidate-service/Models/Resume.cs
+++ b/services/candidate-service/Models/Resume.cs
@@ -7,8 +7,6 @@
         public Guid ProfileId { get; set; }
         public string FileName { get; set; } = string.Empty;
         public string S3Key { get; set; } = string.Empty;
-        
-        public string S3Url { get; set; } = string.Empty;
 
         public bool IsPrimary { get; set; } = false;
 

--- a/services/candidate-service/Services/CandidateService.cs
+++ b/services/candidate-service/Services/CandidateService.cs
@@ -68,7 +68,11 @@ namespace Vettly.CandidateService.Services
             profile.LinkedInUrl = req.LinkedInUrl ?? profile.LinkedInUrl;
             profile.GitHubUrl = req.GitHubUrl ?? profile.GitHubUrl;
             profile.PortfolioUrl = req.PortfolioUrl ?? profile.PortfolioUrl;
-            profile.AvatarUrl = req.AvatarUrl ?? profile.AvatarUrl;
+            if (req.AvatarUrl is not null)
+            {
+                profile.AvatarUrl = req.AvatarUrl;
+                profile.AvatarKey = null;
+            }
             profile.UpdatedAt = DateTime.UtcNow;
 
             await _db.SaveChangesAsync();
@@ -251,14 +255,13 @@ namespace Vettly.CandidateService.Services
         {
             var profile = await GetOrThrowAsync(userId);
 
-            var (key, url) = await _s3.UploadResumeAsync(file, userId);
+            var (key, _) = await _s3.UploadResumeAsync(file, userId);
 
             var resume = new Resume
             {
                 ProfileId = profile.Id,
                 FileName = file.FileName,
                 S3Key = key,
-                S3Url = url,
                 IsPrimary = !await _db.Resumes
                     .AnyAsync(r => r.ProfileId == profile.Id),
             };
@@ -318,7 +321,7 @@ namespace Vettly.CandidateService.Services
             return profile;
         }
 
-        private static ProfileResponse MapToResponse(CandidateProfile profile) => new()
+        private ProfileResponse MapToResponse(CandidateProfile profile) => new()
         {
             Id = profile.Id,
             UserId = profile.UserId,
@@ -332,7 +335,9 @@ namespace Vettly.CandidateService.Services
             LinkedInUrl = profile.LinkedInUrl,
             GitHubUrl = profile.GitHubUrl,
             PortfolioUrl = profile.PortfolioUrl,
-            AvatarUrl = profile.AvatarUrl,
+            AvatarUrl = profile.AvatarKey is not null
+                ? _s3.GetPublicUrl(profile.AvatarKey)
+                : profile.AvatarUrl,
             CreatedAt = profile.CreatedAt,
             UpdatedAt = profile.UpdatedAt,
             Experiences = profile.Experiences.Select(MapExperience).ToList(),
@@ -372,11 +377,11 @@ namespace Vettly.CandidateService.Services
             CreatedAt = skill.CreatedAt,
         };
 
-        private static ResumeResponse MapResume(Resume resume) => new()
+        private ResumeResponse MapResume(Resume resume) => new()
         {
             Id = resume.Id,
             FileName = resume.FileName,
-            S3Url = resume.S3Url,
+            S3Url = _s3.GetPublicUrl(resume.S3Key),
             IsPrimary = resume.IsPrimary,
             UploadedAt = resume.UploadedAt,
         };
@@ -386,13 +391,13 @@ namespace Vettly.CandidateService.Services
                 .FirstOrDefaultAsync(p => p.UserId == userId);
             if (profile is null) return null;
 
-            var (_, url) = await _s3.UploadAvatarAsync(file, userId);
+            var (key, _) = await _s3.UploadAvatarAsync(file, userId);
 
-            profile.AvatarUrl = url;
+            profile.AvatarKey = key;
             profile.UpdatedAt = DateTime.UtcNow;
             await _db.SaveChangesAsync();
 
-            return url;
+            return _s3.GetPublicUrl(key);
         }
     }
 }

--- a/services/candidate-service/Services/S3Service.cs
+++ b/services/candidate-service/Services/S3Service.cs
@@ -58,7 +58,7 @@ namespace Vettly.CandidateService.Services
                 BucketName = _config["R2:BucketName"]!,
                 Key = key,
                 Verb = HttpVerb.GET,
-                Expires = DateTime.UtcNow.AddDays(7),
+                Expires = DateTime.UtcNow.AddHours(1),
             };
             return _s3.GetPreSignedURL(request);
         }


### PR DESCRIPTION
This pull request updates the candidate service database schema to remove the now-unnecessary `S3Url` column from the `Resumes` table and makes a minor addition to the candidate profile. The changes include the migration files to apply and roll back this schema update, as well as corresponding model updates.

**Database schema changes:**

* Removed the `S3Url` column from the `Resumes` table to clean up unused data, with an EF Core migration (`RemoveResumeS3Url`) to handle the schema update. [[1]](diffhunk://#diff-5aa6b1682d8ece244c0abc2dfd1e4f68d8be2984ece46fb18a78dbd98bd991f3R1-R32) [[2]](diffhunk://#diff-831cfb19c33cce54142dd57c3b123f6876556a535ffd34cadd4b8b162879126dR1-R365) [[3]](diffhunk://#diff-165d67e5c97674fe3f1f3c616421dbfccc24565c0db0b00fcf1d5e0f3f1c4042L83)
* Added the `AvatarKey` property to the `CandidateProfile` entity, allowing storage of a key (up to 500 characters) for avatar images.

**Migration files:**

* Added migration files `20260607042258_RemoveResumeS3Url.cs` and its designer to support the schema change and ensure reversibility (restoring the column if needed). [[1]](diffhunk://#diff-5aa6b1682d8ece244c0abc2dfd1e4f68d8be2984ece46fb18a78dbd98bd991f3R1-R32) [[2]](diffhunk://#diff-831cfb19c33cce54142dd57c3b123f6876556a535ffd34cadd4b8b162879126dR1-R365)